### PR TITLE
Set isAccessibilityElement to true

### DIFF
--- a/SwitchControl/SwitchControl/SwitchControl.swift
+++ b/SwitchControl/SwitchControl/SwitchControl.swift
@@ -113,6 +113,7 @@ public class SwitchControl: UIControl {
     // MARK: Accessibility
 
     private func initAccessibility() {
+        isAccessibilityElement = true
         accessibilityTraits = UIAccessibilityTraitButton
         updateAccessibilityValue()
         accessibilityHint = NSLocalizedString("Double tap to toggle", comment: "")

--- a/SwitchControl/SwitchControlTests/SwitchControlTests+Accessibility.swift
+++ b/SwitchControl/SwitchControlTests/SwitchControlTests+Accessibility.swift
@@ -5,6 +5,10 @@ extension SwitchControlTests {
 
     // MARK: Accessibility
 
+    func testIsAccessibilityElement() {
+        XCTAssertTrue(switchControl.isAccessibilityElement)
+    }
+
     func testAccessibilityTraits() {
         XCTAssertEqual(switchControl.accessibilityTraits, UIAccessibilityTraitButton)
     }


### PR DESCRIPTION
If we don't set it to true, voice over recognizes labels inside control instead of selecting control as a single element.
